### PR TITLE
Кнопка "Очистить корзину"

### DIFF
--- a/app/callbacks/cart.py
+++ b/app/callbacks/cart.py
@@ -9,6 +9,7 @@ class CartCallback(CallbackData, prefix="cart"):
 INCREASE_ACTION = "increase"
 DECREASE_ACTION = "decrease"
 REMOVE_ACTION = "remove"
+CLEAR_ACTION = "clear"
 START_CHECKOUT_ACTION = "checkout"
 CONFIRM_ORDER_ACTION = "confirm_order"
 CANCEL_CHECKOUT_ACTION = "cancel_checkout"

--- a/app/handlers/cart.py
+++ b/app/handlers/cart.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.callbacks.cart import (
     CANCEL_CHECKOUT_ACTION,
+    CLEAR_ACTION,
     CONFIRM_ORDER_ACTION,
     DECREASE_ACTION,
     INCREASE_ACTION,
@@ -27,6 +28,7 @@ from app.keyboards.cart import (
 from app.keyboards.main_menu import get_main_menu_keyboard
 from app.models.user import User
 from app.services.cart import (
+    clear_cart,
     decrease_cart_item_quantity,
     get_cart_by_telegram_id,
     increase_cart_item_quantity,
@@ -437,6 +439,27 @@ async def remove_item(
         logger.exception(
             "Database error while removing cart_item_id=%s", callback_data.cart_item_id
         )
+        if callback.message is not None:
+            await callback.message.edit_text(CART_UPDATE_ERROR_TEXT)
+        await callback.answer()
+
+
+@router.callback_query(CartCallback.filter(F.action == CLEAR_ACTION))
+async def clear_items(
+    callback: CallbackQuery,
+    db: AsyncSession,
+) -> None:
+    try:
+        cleared = await clear_cart(db, callback.from_user.id)
+        if not cleared:
+            if callback.message is not None:
+                await callback.message.edit_text(EMPTY_CART_TEXT)
+            await callback.answer()
+            return
+
+        await _update_cart_view(callback, db, callback.from_user.id)
+    except SQLAlchemyError:
+        logger.exception("Database error while clearing cart telegram_id=%s", callback.from_user.id)
         if callback.message is not None:
             await callback.message.edit_text(CART_UPDATE_ERROR_TEXT)
         await callback.answer()

--- a/app/keyboards/cart.py
+++ b/app/keyboards/cart.py
@@ -9,6 +9,7 @@ from aiogram.types import (
 
 from app.callbacks.cart import (
     CANCEL_CHECKOUT_ACTION,
+    CLEAR_ACTION,
     CONFIRM_ORDER_ACTION,
     DECREASE_ACTION,
     INCREASE_ACTION,
@@ -55,6 +56,15 @@ def build_cart_keyboard(cart_items: List[CartItem]) -> InlineKeyboardMarkup:
                 ),
             ]
         )
+
+    inline_keyboard.append(
+        [
+            InlineKeyboardButton(
+                text=get_ui_text("cart", "clear_button"),
+                callback_data=CartCallback(action=CLEAR_ACTION).pack(),
+            )
+        ]
+    )
 
     inline_keyboard.append(
         [

--- a/app/services/cart.py
+++ b/app/services/cart.py
@@ -166,3 +166,25 @@ async def remove_cart_item(
         await session.rollback()
         logger.exception("Failed to remove cart_item_id=%s", cart_item_id)
         raise
+
+
+async def clear_cart(
+    session: AsyncSession,
+    telegram_id: int,
+) -> bool:
+    try:
+        cart = await get_cart_by_telegram_id(session, telegram_id)
+        if cart is None or not cart.items:
+            return False
+
+        for cart_item in list(cart.items):
+            await session.delete(cart_item)
+
+        await session.flush()
+        cart.items.clear()
+        await session.commit()
+        return True
+    except SQLAlchemyError:
+        await session.rollback()
+        logger.exception("Failed to clear cart for telegram_id=%s", telegram_id)
+        raise

--- a/app/ui_texts.json
+++ b/app/ui_texts.json
@@ -33,6 +33,7 @@
     "item_line": "{index}. {name}\nЦена: {price}\nКоличество: {quantity}\nСумма: {total}",
     "total_label": "Итого: {total}",
     "checkout_button": "Оформить заказ",
+    "clear_button": "Очистить корзину",
     "increase_button": "+",
     "decrease_button": "-",
     "remove_item_button": "Удалить {product_name}"

--- a/tests/handlers/test_cart.py
+++ b/tests/handlers/test_cart.py
@@ -14,6 +14,7 @@ from app.callbacks.cart import (
 from app.handlers import cart as cart_module
 from app.handlers.cart import (
     cancel_checkout_by_callback,
+    clear_items,
     confirm_checkout,
     decrease_item,
     increase_item,
@@ -115,6 +116,29 @@ async def test_remove_item_updates_cart(db_session, callback_factory) -> None:
     callback_data = CartCallback(action=REMOVE_ACTION, cart_item_id=cart_item.id)
 
     await remove_item(callback, callback_data, db_session)
+
+    callback.message.edit_text.assert_awaited_once_with("Корзина пуста.")
+
+
+@pytest.mark.asyncio
+async def test_clear_items_updates_cart(db_session, callback_factory) -> None:
+    user, _cart_item = await _seed_cart(db_session)
+    callback = callback_factory()
+    callback.from_user = SimpleNamespace(id=user.telegram_id)
+
+    await clear_items(callback, db_session)
+
+    callback.message.edit_text.assert_awaited_once_with("Корзина пуста.")
+
+
+@pytest.mark.asyncio
+async def test_clear_items_shows_empty_cart_when_already_empty(
+    db_session, callback_factory
+) -> None:
+    callback = callback_factory()
+    callback.from_user = SimpleNamespace(id=222001)
+
+    await clear_items(callback, db_session)
 
     callback.message.edit_text.assert_awaited_once_with("Корзина пуста.")
 

--- a/tests/test_cart_service.py
+++ b/tests/test_cart_service.py
@@ -10,6 +10,7 @@ from app.models.product import Product
 from app.models.user import User
 from app.services.cart import (
     add_product_to_cart,
+    clear_cart,
     decrease_cart_item_quantity,
     get_cart_by_telegram_id,
     increase_cart_item_quantity,
@@ -135,6 +136,27 @@ async def test_remove_cart_item(db_session) -> None:
     removed = await remove_cart_item(db_session, cart_item.id)
 
     assert removed is True
+
+
+@pytest.mark.asyncio
+async def test_clear_cart_removes_all_items(db_session) -> None:
+    user = User(telegram_id=111010, username="user", first_name="User", last_name="Ten")
+    category = Category(name="Одежда")
+    db_session.add_all([user, category])
+    await db_session.flush()
+    first_product = Product(category_id=category.id, name="Футболка", price=Decimal("100.00"))
+    second_product = Product(category_id=category.id, name="Худи", price=Decimal("200.00"))
+    db_session.add_all([first_product, second_product])
+    await db_session.commit()
+    await add_product_to_cart(db_session, user.telegram_id, first_product.id)
+    await add_product_to_cart(db_session, user.telegram_id, second_product.id)
+
+    cleared = await clear_cart(db_session, user.telegram_id)
+    cart = await get_cart_by_telegram_id(db_session, user.telegram_id)
+
+    assert cleared is True
+    assert cart is not None
+    assert cart.items == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_ui_texts.py
+++ b/tests/test_ui_texts.py
@@ -139,7 +139,8 @@ def test_keyboards_preserve_existing_button_copy() -> None:
         "-",
         "Удалить Белая футболка",
     ]
-    assert cart_keyboard.inline_keyboard[1][0].text == "Оформить заказ"
+    assert cart_keyboard.inline_keyboard[1][0].text == "Очистить корзину"
+    assert cart_keyboard.inline_keyboard[2][0].text == "Оформить заказ"
     assert checkout_keyboard.inline_keyboard[0][0].text == "Подтвердить заказ"
     assert checkout_keyboard.inline_keyboard[1][0].text == "Отменить"
 


### PR DESCRIPTION
Closes #7

Что изменено:
- добавлена кнопка `Очистить корзину` на экране корзины
- добавлен callback и handler для полной очистки корзины
- добавлены regression tests на service, handler и тексты UI

Локальная проверка:
- `/home/lynx/telegram_shop_bot/.venv/bin/ruff format ...`
- `/home/lynx/telegram_shop_bot/.venv/bin/ruff check ...`
- `/home/lynx/telegram_shop_bot/.venv/bin/pytest tests/test_ui_texts.py -v`
- `/home/lynx/telegram_shop_bot/.venv/bin/pytest tests/test_cart_service.py tests/handlers/test_cart.py -v --run-integration`

Риски / manual-only gaps:
- manual-only gaps не осталось для changed behavior