### PR TITLE
Страницы в каталоге

### DIFF
--- a/app/callbacks/catalog.py
+++ b/app/callbacks/catalog.py
@@ -8,6 +8,7 @@ class CatalogCallback(CallbackData, prefix="catalog"):
     category_id: Optional[int] = None
     product_id: Optional[int] = None
     parent_category_id: Optional[int] = None
+    page: Optional[int] = None
 
 
 OPEN_CATEGORY_ACTION = "open_category"

--- a/app/handlers/catalog.py
+++ b/app/handlers/catalog.py
@@ -51,6 +51,7 @@ EMPTY_CATEGORY_PRODUCTS_TEXT = get_ui_text("catalog", "empty_category_products")
 CART_UPDATE_ERROR_TEXT = get_ui_text("cart", "update_error")
 CATALOG_BUTTON_TEXT = get_ui_text("main_menu", "catalog_button")
 ADD_TO_CART_SUCCESS_TEXT = get_ui_text("catalog", "add_to_cart_success")
+PRODUCTS_PER_PAGE = 5
 
 
 async def _delete_message_safely(message) -> None:
@@ -94,6 +95,7 @@ async def _render_category_view(
     category: Category,
     message,
     db: AsyncSession,
+    page: int = 0,
 ) -> None:
     child_categories = await get_child_categories(db, category.id)
     if child_categories:
@@ -121,13 +123,23 @@ async def _render_category_view(
         )
         return
 
+    total_products = len(products)
+    last_page = max((total_products - 1) // PRODUCTS_PER_PAGE, 0)
+    current_page = min(max(page, 0), last_page)
+    start = current_page * PRODUCTS_PER_PAGE
+    end = start + PRODUCTS_PER_PAGE
+    page_products = products[start:end]
+
     await _show_text_response(
         message,
-        build_products_text(category, products),
+        build_products_text(category, page_products),
         reply_markup=build_products_keyboard(
-            products=products,
+            products=page_products,
             category_id=category.id,
             parent_category_id=category.parent_id,
+            page=current_page,
+            has_previous_page=current_page > 0,
+            has_next_page=end < total_products,
         ),
     )
 
@@ -136,6 +148,7 @@ async def _render_root_or_category(
     message,
     db: AsyncSession,
     category_id: Optional[int],
+    page: int = 0,
 ) -> None:
     if category_id is None:
         categories = await get_root_categories(db)
@@ -155,7 +168,7 @@ async def _render_root_or_category(
         await _show_text_response(message, CATEGORY_NOT_FOUND_TEXT)
         return
 
-    await _render_category_view(category, message, db)
+    await _render_category_view(category, message, db, page=page)
 
 
 async def _ensure_user_exists(callback: CallbackQuery, db: AsyncSession) -> None:
@@ -212,7 +225,12 @@ async def open_category(
             await callback.answer()
             return
 
-        await _render_category_view(category, callback.message, db)
+        await _render_category_view(
+            category,
+            callback.message,
+            db,
+            page=callback_data.page or 0,
+        )
         await callback.answer()
     except SQLAlchemyError:
         logger.exception(
@@ -246,6 +264,7 @@ async def open_product(
             product_id=product.id,
             category_id=product.category_id,
             parent_category_id=callback_data.parent_category_id,
+            page=callback_data.page or 0,
         )
 
         if product.image_url:
@@ -338,7 +357,12 @@ async def go_back(
         return
 
     try:
-        await _render_root_or_category(callback.message, db, callback_data.category_id)
+        await _render_root_or_category(
+            callback.message,
+            db,
+            callback_data.category_id,
+            page=callback_data.page or 0,
+        )
         await callback.answer()
     except SQLAlchemyError:
         logger.exception(

--- a/app/keyboards/catalog.py
+++ b/app/keyboards/catalog.py
@@ -16,6 +16,8 @@ from app.ui_text import format_ui_text, get_ui_text
 
 BACK_BUTTON_TEXT = get_ui_text("catalog", "back_button")
 ADD_TO_CART_BUTTON_TEXT = get_ui_text("catalog", "add_to_cart_button")
+PREVIOUS_PAGE_BUTTON_TEXT = "⬅️"
+NEXT_PAGE_BUTTON_TEXT = "➡️"
 
 
 def build_root_categories_keyboard(categories: List[Category]) -> InlineKeyboardMarkup:
@@ -63,6 +65,9 @@ def build_products_keyboard(
     products: List[Product],
     category_id: int,
     parent_category_id: Optional[int],
+    page: int,
+    has_previous_page: bool,
+    has_next_page: bool,
 ) -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     for product in products:
@@ -78,6 +83,27 @@ def build_products_keyboard(
                 product_id=product.id,
                 category_id=category_id,
                 parent_category_id=parent_category_id,
+                page=page,
+            ),
+        )
+    if has_previous_page:
+        builder.button(
+            text=PREVIOUS_PAGE_BUTTON_TEXT,
+            callback_data=CatalogCallback(
+                action=OPEN_CATEGORY_ACTION,
+                category_id=category_id,
+                parent_category_id=parent_category_id,
+                page=page - 1,
+            ),
+        )
+    if has_next_page:
+        builder.button(
+            text=NEXT_PAGE_BUTTON_TEXT,
+            callback_data=CatalogCallback(
+                action=OPEN_CATEGORY_ACTION,
+                category_id=category_id,
+                parent_category_id=parent_category_id,
+                page=page + 1,
             ),
         )
     builder.button(
@@ -87,7 +113,10 @@ def build_products_keyboard(
             category_id=parent_category_id,
         ),
     )
-    builder.adjust(1)
+    if has_previous_page or has_next_page:
+        builder.adjust(*([1] * len(products)), 2, 1)
+    else:
+        builder.adjust(*([1] * len(products)), 1)
     return builder.as_markup()
 
 
@@ -95,6 +124,7 @@ def build_product_keyboard(
     product_id: int,
     category_id: int,
     parent_category_id: Optional[int],
+    page: int,
 ) -> InlineKeyboardMarkup:
     builder = InlineKeyboardBuilder()
     builder.button(
@@ -112,6 +142,7 @@ def build_product_keyboard(
             action=GO_BACK_ACTION,
             category_id=category_id,
             parent_category_id=parent_category_id,
+            page=page,
         ),
     )
     builder.adjust(1)

--- a/tests/handlers/test_catalog.py
+++ b/tests/handlers/test_catalog.py
@@ -102,6 +102,80 @@ async def test_open_category_shows_products_for_leaf_category(db_session, callba
 
 
 @pytest.mark.asyncio
+async def test_open_category_paginates_leaf_products(db_session, callback_factory) -> None:
+    category = Category(name="Футболки")
+    db_session.add(category)
+    await db_session.flush()
+    for index in range(1, 8):
+        db_session.add(
+            Product(
+                category_id=category.id,
+                name=f"Товар {index}",
+                price=Decimal("1999.00"),
+                is_active=True,
+            )
+        )
+    await db_session.commit()
+    callback = callback_factory()
+    callback_data = CatalogCallback(action=OPEN_CATEGORY_ACTION, category_id=category.id)
+
+    await open_category(callback, callback_data, db_session)
+
+    callback.message.edit_text.assert_awaited_once()
+    text = callback.message.edit_text.await_args.args[0]
+    assert "Товар 1 - 1999.00 ₽" in text
+    assert "Товар 5 - 1999.00 ₽" in text
+    assert "Товар 6 - 1999.00 ₽" not in text
+    reply_markup = callback.message.edit_text.await_args.kwargs["reply_markup"]
+    assert [button.text for row in reply_markup.inline_keyboard for button in row] == [
+        "Товар 1 - 1999.00 ₽",
+        "Товар 2 - 1999.00 ₽",
+        "Товар 3 - 1999.00 ₽",
+        "Товар 4 - 1999.00 ₽",
+        "Товар 5 - 1999.00 ₽",
+        "➡️",
+        "Назад",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_open_category_opens_requested_products_page(db_session, callback_factory) -> None:
+    category = Category(name="Футболки")
+    db_session.add(category)
+    await db_session.flush()
+    for index in range(1, 8):
+        db_session.add(
+            Product(
+                category_id=category.id,
+                name=f"Товар {index}",
+                price=Decimal("1999.00"),
+                is_active=True,
+            )
+        )
+    await db_session.commit()
+    callback = callback_factory()
+    callback_data = CatalogCallback(
+        action=OPEN_CATEGORY_ACTION,
+        category_id=category.id,
+        page=1,
+    )
+
+    await open_category(callback, callback_data, db_session)
+
+    text = callback.message.edit_text.await_args.args[0]
+    assert "Товар 6 - 1999.00 ₽" in text
+    assert "Товар 7 - 1999.00 ₽" in text
+    assert "Товар 5 - 1999.00 ₽" not in text
+    reply_markup = callback.message.edit_text.await_args.kwargs["reply_markup"]
+    assert [button.text for row in reply_markup.inline_keyboard for button in row] == [
+        "Товар 6 - 1999.00 ₽",
+        "Товар 7 - 1999.00 ₽",
+        "⬅️",
+        "Назад",
+    ]
+
+
+@pytest.mark.asyncio
 async def test_open_category_handles_leaf_without_products(db_session, callback_factory) -> None:
     category = Category(name="Футболки")
     db_session.add(category)
@@ -268,6 +342,32 @@ async def test_go_back_returns_to_parent_category_level_from_media_message(
     callback.message.delete.assert_awaited_once()
     assert "Выберите раздел:" in callback.message.answer.await_args.args[0]
     assert "Футболки" in callback.message.answer.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_go_back_returns_to_same_products_page(db_session, callback_factory) -> None:
+    category = Category(name="Футболки")
+    db_session.add(category)
+    await db_session.flush()
+    for index in range(1, 8):
+        db_session.add(
+            Product(
+                category_id=category.id,
+                name=f"Товар {index}",
+                price=Decimal("1999.00"),
+                is_active=True,
+            )
+        )
+    await db_session.commit()
+    callback = callback_factory()
+    callback_data = CatalogCallback(action=GO_BACK_ACTION, category_id=category.id, page=1)
+
+    await go_back(callback, callback_data, db_session)
+
+    text = callback.message.edit_text.await_args.args[0]
+    assert "Товар 6 - 1999.00 ₽" in text
+    assert "Товар 7 - 1999.00 ₽" in text
+    assert "Товар 5 - 1999.00 ₽" not in text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Что сделано
- добавлена пагинация товаров в листовых категориях по 5 товаров на страницу
- добавлены кнопки перехода между страницами в пределах текущей категории
- сохранён возврат на ту же страницу после открытия карточки товара

## Проверка
- .venv/bin/ruff format app/callbacks/catalog.py app/keyboards/catalog.py app/handlers/catalog.py tests/handlers/test_catalog.py tests/test_catalog_service.py
- .venv/bin/ruff check app/callbacks/catalog.py app/keyboards/catalog.py app/handlers/catalog.py tests/handlers/test_catalog.py tests/test_catalog_service.py
- .venv/bin/pytest tests/test_catalog_service.py tests/handlers/test_catalog.py -v --run-integration

Closes #8