### PR TITLE
Добавить эмоджи на кнопки меню

### DIFF
--- a/app/ui_texts.json
+++ b/app/ui_texts.json
@@ -1,7 +1,7 @@
 {
   "main_menu": {
-    "catalog_button": "Каталог",
-    "cart_button": "Корзина",
+    "catalog_button": "🛍 Каталог",
+    "cart_button": "🛒 Корзина",
     "order_status_button": "Статус заказа",
     "operator_orders_button": "Заказы",
     "admin_catalog_button": "Админ каталог"

--- a/tests/handlers/test_cart.py
+++ b/tests/handlers/test_cart.py
@@ -56,7 +56,7 @@ async def _seed_cart(db_session) -> tuple[User, CartItem]:
 
 @pytest.mark.asyncio
 async def test_open_cart_shows_empty_cart(db_session, message_factory) -> None:
-    message = message_factory(text_value="Корзина")
+    message = message_factory(text_value="🛒 Корзина")
 
     await open_cart(message, db_session)
 
@@ -71,7 +71,7 @@ async def test_open_cart_shows_items(db_session, message_factory) -> None:
         username=user.username,
         first_name=user.first_name,
         last_name=user.last_name,
-        text_value="Корзина",
+        text_value="🛒 Корзина",
     )
 
     await open_cart(message, db_session)
@@ -156,7 +156,7 @@ async def test_cart_action_handles_missing_item(db_session, callback_factory) ->
 
 @pytest.mark.asyncio
 async def test_open_cart_handles_database_error(message_factory, monkeypatch) -> None:
-    message = message_factory(text_value="Корзина")
+    message = message_factory(text_value="🛒 Корзина")
 
     async def broken_get_cart(_session, _telegram_id):
         raise SQLAlchemyError("boom")

--- a/tests/handlers/test_catalog.py
+++ b/tests/handlers/test_catalog.py
@@ -29,7 +29,7 @@ from app.models.user import User
 async def test_open_catalog_shows_root_categories(db_session, message_factory) -> None:
     db_session.add_all([Category(name="Одежда"), Category(name="Техника")])
     await db_session.commit()
-    message = message_factory(text_value="Каталог")
+    message = message_factory(text_value="🛍 Каталог")
 
     await open_catalog(message, db_session)
 
@@ -44,7 +44,7 @@ async def test_open_catalog_shows_root_categories(db_session, message_factory) -
 
 @pytest.mark.asyncio
 async def test_open_catalog_handles_empty_catalog(db_session, message_factory) -> None:
-    message = message_factory(text_value="Каталог")
+    message = message_factory(text_value="🛍 Каталог")
 
     await open_catalog(message, db_session)
 
@@ -392,7 +392,7 @@ async def test_open_product_handles_missing_product(db_session, callback_factory
 
 @pytest.mark.asyncio
 async def test_open_catalog_handles_database_error(message_factory, monkeypatch) -> None:
-    message = message_factory(text_value="Каталог")
+    message = message_factory(text_value="🛍 Каталог")
 
     async def broken_get_root_categories(_session):
         raise SQLAlchemyError("boom")

--- a/tests/handlers/test_start.py
+++ b/tests/handlers/test_start.py
@@ -24,8 +24,8 @@ async def test_start_registers_new_user(db_session, message_factory) -> None:
     message.answer.assert_awaited_once()
     assert "Добро пожаловать" in message.answer.await_args.args[0]
     reply_markup = message.answer.await_args.kwargs["reply_markup"]
-    assert reply_markup.keyboard[0][0].text == "Каталог"
-    assert reply_markup.keyboard[0][1].text == "Корзина"
+    assert reply_markup.keyboard[0][0].text == "🛍 Каталог"
+    assert reply_markup.keyboard[0][1].text == "🛒 Корзина"
     assert reply_markup.keyboard[1][0].text == "Статус заказа"
     assert len(reply_markup.keyboard) == 2
 

--- a/tests/test_ui_texts.py
+++ b/tests/test_ui_texts.py
@@ -131,7 +131,12 @@ def test_keyboards_preserve_existing_button_copy() -> None:
     product = SimpleNamespace(id=1, name="Белая футболка", price=Decimal("1999.00"))
     cart_item = SimpleNamespace(id=5, product=product)
 
-    product_keyboard = build_product_keyboard(product_id=1, category_id=2, parent_category_id=3)
+    product_keyboard = build_product_keyboard(
+        product_id=1,
+        category_id=2,
+        parent_category_id=3,
+        page=0,
+    )
     cart_keyboard = build_cart_keyboard([cart_item])
     checkout_keyboard = build_checkout_confirmation_keyboard()
     payment_keyboard = build_payment_confirmation_keyboard("https://pay.example/1")

--- a/tests/test_ui_texts.py
+++ b/tests/test_ui_texts.py
@@ -37,7 +37,7 @@ def test_load_ui_texts_returns_dict() -> None:
     data = load_ui_texts()
 
     assert isinstance(data, dict)
-    assert data["main_menu"]["catalog_button"] == "Каталог"
+    assert data["main_menu"]["catalog_button"] == "🛍 Каталог"
     assert data["main_menu"]["order_status_button"] == "Статус заказа"
 
 
@@ -64,8 +64,8 @@ def test_main_menu_keyboard_uses_json_texts() -> None:
     operator_keyboard = get_main_menu_keyboard("operator")
     admin_keyboard = get_main_menu_keyboard("admin")
 
-    assert keyboard.keyboard[0][0].text == "Каталог"
-    assert keyboard.keyboard[0][1].text == "Корзина"
+    assert keyboard.keyboard[0][0].text == "🛍 Каталог"
+    assert keyboard.keyboard[0][1].text == "🛒 Корзина"
     assert keyboard.keyboard[1][0].text == "Статус заказа"
     assert len(keyboard.keyboard) == 2
     assert operator_keyboard.keyboard[2][0].text == "Заказы"


### PR DESCRIPTION
## Что сделано
- добавлены эмоджи на кнопки главного меню каталога и корзины
- обновлены связанные тесты UI и хендлеров
- отдельно исправлен устаревший regression test для build_product_keyboard

## Проверка
- ruff check для измененных Python-файлов
- pytest tests/test_ui_texts.py -q

Closes #12